### PR TITLE
BF: Ensure little-endian whatever the platform. trx should works on s…

### DIFF
--- a/trx/workflows.py
+++ b/trx/workflows.py
@@ -417,10 +417,12 @@ def _write_header(tmp_dir_name, reference, streamlines):
 def _write_streamline_data(tmp_dir_name, streamlines, positions_dtype, offsets_dtype):
     """Write streamline position and offset data."""
     curr_filename = os.path.join(tmp_dir_name, "positions.3.{}".format(positions_dtype))
-    streamlines._data.astype(positions_dtype).tofile(curr_filename)
+    positions = streamlines._data.astype(positions_dtype)
+    tmm._ensure_little_endian(positions).tofile(curr_filename)
 
     curr_filename = os.path.join(tmp_dir_name, "offsets.{}".format(offsets_dtype))
-    streamlines._offsets.astype(offsets_dtype).tofile(curr_filename)
+    offsets = streamlines._offsets.astype(offsets_dtype)
+    tmm._ensure_little_endian(offsets).tofile(curr_filename)
 
 
 def _normalize_dtype(dtype_str):
@@ -460,7 +462,7 @@ def _write_data_array(tmp_dir_name, subdir_name, args, is_dpg=False):
             tmp_dir_name, subdir_name, "{}.{}{}".format(basename, dim, dtype)
         )
 
-    curr_arr.tofile(curr_filename)
+    tmm._ensure_little_endian(curr_arr).tofile(curr_filename)
 
 
 def generate_trx_from_scratch(  # noqa: C901


### PR DESCRIPTION
fixes #83

This pull request introduces a better handling of endianness to ensure cross-platform compatibility when reading and writing TRX files. The changes add utility functions to enforce little-endian byte order, update all relevant file writing operations to use these utilities, and include extensive tests to verify correct behavior for various data types and scenarios.

* Added `_get_dtype_little_endian` and `_ensure_little_endian` utility functions in `trx_file_memmap.py` to convert data types and arrays to little-endian format, ensuring all data written to disk conforms to the TRX file specification for cross-platform compatibility.
* Updated all file writing operations in `TrxFile.deepcopy` and related functions to use `_ensure_little_endian`, ensuring that positions, offsets, and all per-vertex, per-streamline, and per-group data are saved in little-endian byte order. [[1]](diffhunk://#diff-29ac7f74c8fe9293690330ea774b13672b132e68512fefc7969d9e5a675c3570L809-R870) [[2]](diffhunk://#diff-29ac7f74c8fe9293690330ea774b13672b132e68512fefc7969d9e5a675c3570L822-R883) [[3]](diffhunk://#diff-29ac7f74c8fe9293690330ea774b13672b132e68512fefc7969d9e5a675c3570L835-R896) [[4]](diffhunk://#diff-29ac7f74c8fe9293690330ea774b13672b132e68512fefc7969d9e5a675c3570L844-R905) [[5]](diffhunk://#diff-29ac7f74c8fe9293690330ea774b13672b132e68512fefc7969d9e5a675c3570L853-R914) [[6]](diffhunk://#diff-29ac7f74c8fe9293690330ea774b13672b132e68512fefc7969d9e5a675c3570L867-R928)
* Modified the `_create_memmap` function to always use little-endian dtypes when mapping files, and updated the test for memmap creation accordingly. [[1]](diffhunk://#diff-29ac7f74c8fe9293690330ea774b13672b132e68512fefc7969d9e5a675c3570R260-R262) [[2]](diffhunk://#diff-a434baf5e9f28bad72426734b43cad110ee7e913475b47a2a452bb9bbfc84c02L127-R131)
* Updated `trx/workflows.py` to ensure all streamline and data arrays are written in little-endian order using the new utility functions, covering positions, offsets, and additional data arrays. [[1]](diffhunk://#diff-55ee98ba8c883f94c98c6d6fc88d29ebcb6c3e860c6ae997a83dc05690e5b86bL420-R425) [[2]](diffhunk://#diff-55ee98ba8c883f94c98c6d6fc88d29ebcb6c3e860c6ae997a83dc05690e5b86bL463-R465)
* Added comprehensive tests in `test_memmap.py` to verify correct dtype conversion, array onversion, and roundtrip data integrity for various data types and endianness scenarios.