### PR TITLE
TEST: build the ZIP fixture little-endian in the local-header test

### DIFF
--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -523,10 +523,12 @@ def test_load_zip_with_local_header_extra_field():
             local_info = []
             extra = b"\x00\x00\x04\x00TEST"  # 8-byte extra field
 
+            # TRX stores arrays little-endian on disk; serialize the fixture
+            # explicitly so it is valid on big-endian hosts too (issue #113).
             for name, data in [
                 ("header.json", json.dumps(header).encode()),
-                ("positions.3.float32", positions.tobytes()),
-                ("offsets.uint64", offsets.tobytes()),
+                ("positions.3.float32", positions.astype("<f4").tobytes()),
+                ("offsets.uint64", offsets.astype("<u8").tobytes()),
             ]:
                 offset = f.tell()
                 fname = name.encode()

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -523,8 +523,6 @@ def test_load_zip_with_local_header_extra_field():
             local_info = []
             extra = b"\x00\x00\x04\x00TEST"  # 8-byte extra field
 
-            # TRX stores arrays little-endian on disk; serialize the fixture
-            # explicitly so it is valid on big-endian hosts too (issue #113).
             for name, data in [
                 ("header.json", json.dumps(header).encode()),
                 ("positions.3.float32", positions.astype("<f4").tobytes()),


### PR DESCRIPTION
Fixes #113 — `test_load_zip_with_local_header_extra_field` fails on s390x (and any big-endian host).

The test hand-builds a ZIP fixture and wrote the `positions` / `offsets` arrays with `.tobytes()`, which serializes in **native** byte order. The TRX format stores arrays **little-endian** on disk (`_get_dtype_little_endian` / `_ensure_little_endian`), and the loader decodes them little-endian. So on a big-endian host the fixture wrote big-endian bytes that the (correct) reader then byte-swapped — the test failed with mismatched streamline values.

This is a test-fixture bug, not a library bug: the library's read and write paths are both consistently little-endian.

## Fix

Serialize the fixture arrays explicitly as little-endian — `positions.astype("<f4").tobytes()` and `offsets.astype("<u8").tobytes()` — so the hand-built ZIP is a valid TRX file regardless of host endianness. The ZIP headers were already written with explicit little-endian `struct.pack("<...")`; library code is untouched.

## Verification

- Full `test_memmap.py` suite passes on x86_64 (83 passed) — no regression.
- Big-endian behaviour confirmed by simulation: a native `.tobytes()` of a big-endian array does **not** match the little-endian on-disk form, while `.astype("<f4").tobytes()` does.