### PR TITLE
Synthetic tests for zip64 extra_fields

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,6 +14,7 @@
 # import os
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
+import warnings
 import os
 from datetime import datetime as dt
 
@@ -67,7 +68,6 @@ extensions = [
 
 # Suppress known deprecation warnings from dependencies
 # astroid 4.x deprecation - will be fixed when sphinx-autoapi updates for astroid 5.x
-import warnings
 warnings.filterwarnings(
     'ignore',
     message="importing .* from 'astroid' is deprecated",
@@ -180,9 +180,9 @@ _reference_urls = {
 
 # Sphinx gallery configuration
 sphinx_gallery_conf = {
-     'examples_dirs': '../../examples',
-     'gallery_dirs': 'auto_examples',
-     'within_subsection_order': 'NumberOfCodeLinesSortKey',
-     'reference_url': _validate_reference_urls(_reference_urls),
-     'default_thumb_file': os.path.join(os.path.dirname(__file__), '..', '_static', 'trx_logo.png'),
+    'examples_dirs': '../../examples',
+    'gallery_dirs': 'auto_examples',
+    'within_subsection_order': 'NumberOfCodeLinesSortKey',
+    'reference_url': _validate_reference_urls(_reference_urls),
+    'default_thumb_file': os.path.join(os.path.dirname(__file__), '..', '_static', 'trx_logo.png'),
 }

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -498,6 +498,107 @@ def test__ensure_little_endian_big_endian_input():
     assert result[0] == 0x12345678
 
 
+def test_load_zip64_with_extra_fields():
+    """Test loading ZIP64 files where both local and CD headers have extra fields.
+
+    Rust and other tools always write ZIP64 extended information (extra field
+    ID 0x0001, 20 bytes: 4-byte tag+size + 8-byte orig + 8-byte comp) in both
+    local file headers and central directory entries, even for small files.
+    This ensures the data offset is computed correctly by reading the local
+    header's extra_len rather than assuming a fixed layout.
+    """
+    positions = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+    offsets = np.array([0, 2], dtype=np.uint64)
+    header = {
+        "DIMENSIONS": [10, 10, 10],
+        "VOXEL_TO_RASMM": np.eye(4).tolist(),
+        "NB_VERTICES": 2,
+        "NB_STREAMLINES": 1,
+    }
+
+    def make_zip64_extra(orig_size, comp_size):
+        data = struct.pack("<QQ", orig_size, comp_size)
+        return struct.pack("<HH", 0x0001, len(data)) + data
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        trx_path = os.path.join(tmp_dir, "test_zip64.trx")
+
+        with open(trx_path, "wb") as f:
+            local_info = []
+
+            for name, data in [
+                ("header.json", json.dumps(header).encode()),
+                ("positions.3.float32", positions.astype("<f4").tobytes()),
+                ("offsets.uint64", offsets.astype("<u8").tobytes()),
+            ]:
+                offset = f.tell()
+                fname = name.encode()
+                crc = zipfile.crc32(data)
+                # ZIP64 extended info in local header (20 bytes)
+                extra = make_zip64_extra(len(data), len(data))
+                f.write(
+                    struct.pack(
+                        "<4sHHHHHIIIHH",
+                        b"PK\x03\x04",
+                        45,  # version needed: ZIP64
+                        0, 0, 0, 0,
+                        crc,
+                        len(data),
+                        len(data),
+                        len(fname),
+                        len(extra),
+                    )
+                )
+                f.write(fname)
+                f.write(extra)
+                f.write(data)
+                local_info.append((name, offset, crc, len(data)))
+
+            cd_start = f.tell()
+            for name, offset, crc, size in local_info:
+                fname = name.encode()
+                # ZIP64 extended info in central directory entry (20 bytes)
+                extra = make_zip64_extra(size, size)
+                f.write(
+                    struct.pack(
+                        "<4sHHHHHHIIIHHHHHII",
+                        b"PK\x01\x02",
+                        45,  # version made by: ZIP64
+                        45,  # version needed: ZIP64
+                        0, 0, 0, 0,
+                        crc,
+                        size,
+                        size,
+                        len(fname),
+                        len(extra),
+                        0, 0, 0, 0,
+                        offset,
+                    )
+                )
+                f.write(fname)
+                f.write(extra)
+
+            cd_size = f.tell() - cd_start
+            f.write(
+                struct.pack(
+                    "<4sHHHHIIH",
+                    b"PK\x05\x06",
+                    0, 0,
+                    len(local_info),
+                    len(local_info),
+                    cd_size,
+                    cd_start,
+                    0,
+                )
+            )
+
+        trx = tmm.load_from_zip(trx_path)
+        np.testing.assert_array_almost_equal(trx.streamlines._data, positions)
+        assert trx.header["NB_VERTICES"] == 2
+        assert trx.header["NB_STREAMLINES"] == 1
+        trx.close()
+
+
 def test_load_zip_with_local_header_extra_field():
     """Test loading ZIP where local header has extra field not in central dir.
 

--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -541,7 +541,10 @@ def test_load_zip64_with_extra_fields():
                         "<4sHHHHHIIIHH",
                         b"PK\x03\x04",
                         45,  # version needed: ZIP64
-                        0, 0, 0, 0,
+                        0,
+                        0,
+                        0,
+                        0,
                         crc,
                         len(data),
                         len(data),
@@ -565,13 +568,19 @@ def test_load_zip64_with_extra_fields():
                         b"PK\x01\x02",
                         45,  # version made by: ZIP64
                         45,  # version needed: ZIP64
-                        0, 0, 0, 0,
+                        0,
+                        0,
+                        0,
+                        0,
                         crc,
                         size,
                         size,
                         len(fname),
                         len(extra),
-                        0, 0, 0, 0,
+                        0,
+                        0,
+                        0,
+                        0,
                         offset,
                     )
                 )
@@ -583,7 +592,8 @@ def test_load_zip64_with_extra_fields():
                 struct.pack(
                     "<4sHHHHIIH",
                     b"PK\x05\x06",
-                    0, 0,
+                    0,
+                    0,
                     len(local_info),
                     len(local_info),
                     cd_size,

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -762,7 +762,7 @@ def _setup_groups_for_concatenation(
         count = 0
         for curr_trx in trx_list:
             curr_len = len(curr_trx.groups[group_key])
-            new_trx.groups[group_key][pos : pos + curr_len] = (
+            new_trx.groups[group_key][pos: pos + curr_len] = (
                 curr_trx.groups[group_key] + count
             )
             pos += curr_len

--- a/trx/trx_file_memmap.py
+++ b/trx/trx_file_memmap.py
@@ -762,7 +762,7 @@ def _setup_groups_for_concatenation(
         count = 0
         for curr_trx in trx_list:
             curr_len = len(curr_trx.groups[group_key])
-            new_trx.groups[group_key][pos: pos + curr_len] = (
+            new_trx.groups[group_key][pos : pos + curr_len] = (
                 curr_trx.groups[group_key] + count
             )
             pos += curr_len


### PR DESCRIPTION
Extra verification for zip64 extra_fields due to benchmarking across languages. Data from trx-rs seems to write each individual files as "large_file" which add the information in extra_fields. New test for safety.