### PR TITLE
MNT: Ignore the JetBrains IDE project config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,9 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# IDE configuration
+.idea/
 .vscode/
 
 tmp/


### PR DESCRIPTION
Ignore the JetBrains IDE project config folder.