### PR TITLE
STY: Use simple underscores in test function names

### DIFF
--- a/trx/tests/test_memmap.py
+++ b/trx/tests/test_memmap.py
@@ -36,7 +36,7 @@ tmp_dir = get_trx_tmp_dir()
         (np.ones((1), dtype=np.float64), "mean_fa.float64", False),
     ],
 )
-def test__generate_filename_from_data(
+def test_generate_filename_from_data(
     arr, expected, value_error, filename="mean_fa.bit"
 ):
     if value_error:
@@ -60,7 +60,7 @@ def test__generate_filename_from_data(
         ),
     ],
 )
-def test__split_ext_with_dimensionality(filename, expected, value_error):
+def test_split_ext_with_dimensionality(filename, expected, value_error):
     if value_error:
         with pytest.raises(ValueError):
             assert tmm._split_ext_with_dimensionality(filename) == expected
@@ -83,7 +83,7 @@ def test__split_ext_with_dimensionality(filename, expected, value_error):
         ),
     ],
 )
-def test__compute_lengths(offsets, nb_vertices, expected):
+def test_compute_lengths(offsets, nb_vertices, expected):
     offsets = tmm._append_last_offsets(offsets, nb_vertices)
     lengths = tmm._compute_lengths(offsets=offsets)
     assert np.array_equal(lengths, expected)
@@ -99,7 +99,7 @@ def test__compute_lengths(offsets, nb_vertices, expected):
         (".txt", False),
     ],
 )
-def test__is_dtype_valid(ext, expected):
+def test_is_dtype_valid(ext, expected):
     assert tmm._is_dtype_valid(ext) == expected
 
 
@@ -114,7 +114,7 @@ def test__is_dtype_valid(ext, expected):
         (np.zeros((5), dtype=np.int16), 3, 3, -1),
     ],
 )
-def test__dichotomic_search(arr, l_bound, r_bound, expected):
+def test_dichotomic_search(arr, l_bound, r_bound, expected):
     end_idx = tmm._dichotomic_search(arr, l_bound=l_bound, r_bound=r_bound)
     assert end_idx == expected
 
@@ -126,7 +126,7 @@ def test__dichotomic_search(arr, l_bound, r_bound, expected):
         ("offsets.float32", False, None),
     ],
 )
-def test__create_memmap(basename, create, expected):
+def test_create_memmap(basename, create, expected):
     if create:
         with get_trx_tmp_dir() as dirname:
             filename = os.path.join(dirname, basename)
@@ -445,7 +445,7 @@ def test_close_releases_mmap_from_zip(path):
         (np.bool_, "|"),
     ],
 )
-def test__get_dtype_little_endian(dtype_input, expected_byteorder):
+def test_get_dtype_little_endian(dtype_input, expected_byteorder):
     """Test that _get_dtype_little_endian correctly converts dtypes."""
     result = tmm._get_dtype_little_endian(dtype_input)
     assert result.byteorder == expected_byteorder or (
@@ -464,7 +464,7 @@ def test__get_dtype_little_endian(dtype_input, expected_byteorder):
         (np.uint64, 0xDEADBEEFCAFEBABE),
     ],
 )
-def test__ensure_little_endian(dtype, test_value):
+def test_ensure_little_endian(dtype, test_value):
     """Test that _ensure_little_endian correctly converts arrays."""
     # Create array in native byte order
     arr = np.array([test_value], dtype=dtype)
@@ -482,7 +482,7 @@ def test__ensure_little_endian(dtype, test_value):
         assert result[0] == test_value
 
 
-def test__ensure_little_endian_big_endian_input():
+def test_ensure_little_endian_big_endian_input():
     """Test _ensure_little_endian with explicitly big-endian input."""
     # Create a big-endian array
     big_endian_dtype = np.dtype(">u4")


### PR DESCRIPTION
Use simple underscores in test function names to be consistent with `pytest`'s proposed style.