### PR TITLE
MNT: List optional dependencies and test in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[test]
+          python -m pip install -e .[test,utils]
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,3 +38,28 @@ jobs:
 
       - name: Test
         run: spin test
+
+  test-optional-deps:
+    name: Optional deps
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies (including DIPY)
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[dev,test,utils]
+          python -c "import trx; print(trx.__version__)"
+          python -c "import dipy; print(dipy.__version__)"
+
+      - name: Test with DIPY installed
+        run: spin test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+utils = [
+    "dipy",
+    "fury >= 0.10.0, < 2.0.0"
+]
 dev = [
     "spin >= 0.13",
     "setuptools_scm",
@@ -59,6 +63,7 @@ test = [
     "pytest-cov",
 ]
 all = [
+    "trx-python[utils]",
     "trx-python[dev]",
     "trx-python[doc]",
     "trx-python[style]",


### PR DESCRIPTION
List optional dependencies and add a job to the CI workflows so that the related tests are run.

Install the optional dependencies in the coverage workflow CI so that a faithful coverage is reported.